### PR TITLE
Initialize story and dialog strings with zeroes

### DIFF
--- a/src/DoomCanvas.c
+++ b/src/DoomCanvas.c
@@ -732,7 +732,7 @@ void DoomCanvas_drawCredits(DoomCanvas_t* doomCanvas)
 	int len;
 	if (doomCanvas->creditsTextTime == -1) {
 		len = SDL_strlen(creditsText);
-		doomCanvas->creditsText = SDL_malloc(len + 1);
+		doomCanvas->creditsText = SDL_calloc(len + 1, sizeof(char));
 		strcpy_s(doomCanvas->creditsText, len + 1, creditsText);
 		doomCanvas->creditsTextTime = doomCanvas->time;
 
@@ -2232,15 +2232,15 @@ void DoomCanvas_loadPrologueText(DoomCanvas_t* doomCanvas)
 	Sound_playSound(doomCanvas->doomRpg->sound, 5039, SND_FLG_LOOP | SND_FLG_STOPSOUNDS | SND_FLG_ISMUSIC, 5);
 
 	textLen = SDL_strlen(storyTextA);
-	doomCanvas->storyText1[0] = SDL_malloc(textLen + 1);
+	doomCanvas->storyText1[0] = SDL_calloc(textLen + 1, sizeof(char));
 	strncpy_s(doomCanvas->storyText1[0], textLen + 1, storyTextA, textLen);
 
 	textLen = SDL_strlen(storyTextB);
-	doomCanvas->storyText1[1] = SDL_malloc(textLen + 1);
+	doomCanvas->storyText1[1] = SDL_calloc(textLen + 1, sizeof(char));
 	strncpy_s(doomCanvas->storyText1[1], textLen + 1, storyTextB, textLen);
 
 	textLen = SDL_strlen(storyTextC);
-	doomCanvas->storyText2 = SDL_malloc(textLen + 1);
+	doomCanvas->storyText2 = SDL_calloc(textLen + 1, sizeof(char));
 	strncpy_s(doomCanvas->storyText2, textLen + 1, storyTextC, textLen);
 
 	DoomRPG_createImage(doomCanvas->doomRpg, "c.bmp", false, &doomCanvas->imgSpaceBG);

--- a/src/Render.c
+++ b/src/Render.c
@@ -695,7 +695,7 @@ boolean Render_beginLoadMapData(Render_t* render)
 		render->mapStringCount = 0;
 		while (render->mapStringCount < numStrings) {
 			strSize = DoomRPG_shortAtNext(ioBuffer, &render->ioBufferPos);
-			render->mapStringsIDs[render->mapStringCount] = SDL_malloc(strSize + 1 * sizeof(char));
+			render->mapStringsIDs[render->mapStringCount] = SDL_calloc(strSize + 1, sizeof(char));
 			strncpy_s(render->mapStringsIDs[render->mapStringCount], strSize + 1, &ioBuffer[render->ioBufferPos], strSize);
 			render->ioBufferPos += strSize;
 			render->mapStringCount++;


### PR DESCRIPTION
While working on the Vita port, I've encountered garbage characters in the prologue cutscene and almost every dialog after that. This PR fixes that, please let me know if I missed anything. An example of the problem :

<img src="https://github.com/Erick194/DoomRPG-RE/assets/8123702/a5db3c91-ff75-457a-9bbd-d4065d8f9fb5" width="480" />

Not sure if this is specific to Vita, because it does not happen on your PC version, but I thought it may prevent some problems in the future.

Thank you for the amazing work!