### PR TITLE
Misc bugfixes

### DIFF
--- a/src/DoomCanvas.c
+++ b/src/DoomCanvas.c
@@ -419,7 +419,7 @@ void DoomCanvas_combatState(DoomCanvas_t* doomCanvas)
 void DoomCanvas_dialogState(DoomCanvas_t* doomCanvas)
 {
 	char text[8];
-	int strBeg, strEnd, strNxt, strlen;
+	int strBeg, strEnd, strNxt, strLen;
 	int i, posY;
 	boolean strblink;
 
@@ -488,14 +488,14 @@ void DoomCanvas_dialogState(DoomCanvas_t* doomCanvas)
 
 		strblink = ((DoomRPG_GetUpTimeMS() / 300) & 1) == 1;
 
-		strlen = SDL_strlen(doomCanvas->passCode);
-		if (strlen < (int)SDL_strlen(doomCanvas->strPassCode))
+		strLen = SDL_strlen(doomCanvas->passCode);
+		if (strLen < (int)SDL_strlen(doomCanvas->strPassCode))
 		{
 			if (strblink) {
-				doomCanvas->strPassCode[strlen] = '_';
+				doomCanvas->strPassCode[strLen] = '_';
 			}
 			else {
-				doomCanvas->strPassCode[strlen] = sdlController.gGameController ? doomCanvas->passInput : ' ';
+				doomCanvas->strPassCode[strLen] = sdlController.gGameController ? doomCanvas->passInput : ' ';
 			}
 		}
 	}

--- a/src/DoomRPG.c
+++ b/src/DoomRPG.c
@@ -113,6 +113,7 @@ fixed_t	DoomRPG_FixedDiv(fixed_t a, fixed_t b)
 	//return DoomRPG_FixedDiv2(a, b);
 }
 
+/*
 fixed_t	DoomRPG_FixedDiv2(fixed_t a, fixed_t b)
 {
 #if 0
@@ -131,6 +132,7 @@ fixed_t	DoomRPG_FixedDiv2(fixed_t a, fixed_t b)
 	return (fixed_t)c;
 #endif
 }
+*/
 
 static Uint32 basetime = 0;
 
@@ -698,7 +700,7 @@ void DoomRPG_createImage(DoomRPG_t* doomrpg, const char* resourceName, boolean i
 		DoomRPG_Error("Error with SDL_RWFromMem: %s\n", SDL_GetError());
 	}
 
-	loadedSurface = SDL_LoadBMP_RW(rw, 0);
+	loadedSurface = SDL_LoadBMP_RW(rw, SDL_TRUE);
 
 	if (loadedSurface == NULL) {
 		DoomRPG_Error("Unable to load image %s! SDL Error: %s\n", fileName, SDL_GetError());
@@ -774,7 +776,7 @@ void DoomRPG_createImageBerserkColor(DoomRPG_t* doomrpg, const char* resourceNam
 		DoomRPG_Error("Error with SDL_RWFromMem: %s\n", SDL_GetError());
 	}
 
-	loadedSurface = SDL_LoadBMP_RW(rw, 0);
+	loadedSurface = SDL_LoadBMP_RW(rw, SDL_TRUE);
 
 	if (loadedSurface == NULL) {
 		DoomRPG_Error("Unable to load image %s! SDL Error: %s\n", fileName, SDL_GetError());

--- a/src/Main.c
+++ b/src/Main.c
@@ -168,28 +168,27 @@ int main(int argc, char* args[])
 					break;
 				}
 			}
-		}
 
-		key = DoomRPG_getEventKey(mouse_Button, state);
-		if (key != oldKey) {
-			//printf("oldKey %d\n", oldKey);
-			//printf("key %d\n", key);
+			key = DoomRPG_getEventKey(mouse_Button, state);
+			if (key != oldKey) {
+				//printf("oldKey %d\n", oldKey);
+				//printf("key %d\n", key);
 
-			oldKey = key;
-			if (!doomRpg->menuSystem->setBind) {
-				DoomCanvas_keyPressed(doomRpg->doomCanvas, key);
+				oldKey = key;
+				if (!doomRpg->menuSystem->setBind) {
+					DoomCanvas_keyPressed(doomRpg->doomCanvas, key);
+				}
+				else {
+					goto setBind;
+				}
 			}
-			else {
-				goto setBind;
+			else if (key == 0) {
+			setBind:
+				if (doomRpg->menuSystem->setBind) {
+					DoomRPG_setBind(doomRpg, mouse_Button, state);
+				}
 			}
 		}
-		else if (key == 0) {
-		setBind:
-			if (doomRpg->menuSystem->setBind) {
-				DoomRPG_setBind(doomRpg, mouse_Button, state);
-			}
-		}
-
 		
 		if (currentTimeMillis > UpTime) {
 			UpTime = currentTimeMillis + 15;

--- a/src/Menu.c
+++ b/src/Menu.c
@@ -68,6 +68,9 @@ void Menu_LoadHelpResource(Menu_t* menu)
 			if (c == '~') {
 				textLine[j] = 0x80;
 			}
+			else if (c == '\r') {
+				textLine[j] = 0;
+			}
 			else {
 				textLine[j] = c;
 			}

--- a/src/MenuSystem.c
+++ b/src/MenuSystem.c
@@ -565,7 +565,13 @@ void MenuSystem_setMenu(MenuSystem_t* menuSystem, int menu)
 	}
 	else {
 		Render_setGrayPalettes(menuSystem->doomRpg->render);
+		short fColor = menuSystem->doomRpg->render->floorColor[0];
+		short cColor = menuSystem->doomRpg->render->ceilingColor[0];
 		Render_setup(menuSystem->doomRpg->render, &menuSystem->doomRpg->doomCanvas->displayRect);
+		for (int i = 0; i < menuSystem->doomRpg->render->screenWidth; i++) {
+			menuSystem->doomRpg->render->floorColor[i] = fColor;
+			menuSystem->doomRpg->render->ceilingColor[i] = cColor;
+		}
 		iVar2 = menuSystem->doomRpg->render->mapCameraSpawnIndex;
 		if (iVar2 != 0) {
 			menuSystem->doomRpg->doomCanvas->viewX = ((iVar2 % 32) << 6) + 32;

--- a/src/Sound.c
+++ b/src/Sound.c
@@ -87,7 +87,7 @@ Sound_t* Sound_init(Sound_t* sound, DoomRPG_t* doomRpg)
 			//if (!rw) {
 			//	DoomRPG_Error("Error with SDL_RWFromMem: %s\n", SDL_GetError());
 			//}
-			//sound->audioFiles[i].ptr = Mix_LoadMUS_RW(rw, 0);
+			//sound->audioFiles[i].ptr = Mix_LoadMUS_RW(rw, SDL_TRUE);
 
 			sound->audioFiles[i].ptr = (fluid_player_t*)new_fluid_player(fluidSynth.synth);
 			fluid_player_add_mem((fluid_player_t*)sound->audioFiles[i].ptr, fdata, fSize);
@@ -102,7 +102,7 @@ Sound_t* Sound_init(Sound_t* sound, DoomRPG_t* doomRpg)
 			if (!rw) {
 				DoomRPG_Error("Error with SDL_RWFromMem: %s\n", SDL_GetError());
 			}
-			sound->audioFiles[i].ptr = Mix_LoadWAV_RW(rw, 0);
+			sound->audioFiles[i].ptr = Mix_LoadWAV_RW(rw, SDL_TRUE);
 			SDL_free(fdata);
 		}
 	}
@@ -279,7 +279,7 @@ void Sound_loadSound(Sound_t* sound, int chan, short resourceID)
 			DoomRPG_Error("Error with SDL_RWFromMem: %s\n", SDL_GetError());
 		}
 
-		sChannel->mediaAudioMusic = Mix_LoadMUS_RW(rw, 0);
+		sChannel->mediaAudioMusic = Mix_LoadMUS_RW(rw, SDL_TRUE);
 		SDL_free(fdata);
 #endif
 	}
@@ -299,7 +299,7 @@ void Sound_loadSound(Sound_t* sound, int chan, short resourceID)
 		if (!rw) {
 			DoomRPG_Error("Error with SDL_RWFromMem: %s\n", SDL_GetError());
 		}
-		sChannel->mediaAudioSound = Mix_LoadWAV_RW(rw, 0);
+		sChannel->mediaAudioSound = Mix_LoadWAV_RW(rw, SDL_TRUE);
 		SDL_free(fdata);
 #endif
 	}


### PR DESCRIPTION
These fixes aren't really related, mostly small things I found during my playthrough.

- I renamed a variable that could clash with the C library strlen function: a624c9cabd3f76d185659b84f043a224b02d40c9
- the RWops stream wasn't closed by SDL_LoadBMP_RW, Mix_LoadWAV_RW, etc. causing a tiny memory leak: 8280e0eec730780a678f918584151759559fbf91, 9850a6e05d6f9d2e2fb2f9f606b9b76f24d56613
- I moved DoomRPG_getEventKey into the SDL_PollEvent loop, this makes the input more responsive on slow systems: 0ccb13d6fc0d88fd2e945e5399d078d273b5952d
- the CR character is now filtered from help.txt for systems that don't use CRLF: c75158da111ab5f6e7ad7061c86a1360f68bfb09
- the stats screen used uninitialized memory as the floor/ceiling color: 79753c6631b8846136a709ed06a1b174a7aee0eb